### PR TITLE
kuber-intro homework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # sybertuk_platform
 sybertuk Platform repository
+
+- Добавлен докер образ для запуск вебсервера на порту 8000 в диретории /app
+- Добавлен web-pod.yaml манифест для запуска созданного образа в кластере кубера
+- Добавлена yaml конфигурация hipster frontend-a а также ее исправленная версия frontend-pod.yaml

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -3,10 +3,7 @@ kind: Pod
 metadata:
   labels:
     run: frontend
-    manager: kubectl
-    operation: Update
   name: frontend
-  namespace: default
 spec:
   containers:
   - args:

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,42 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: "2020-08-10T21:01:00Z"
   labels:
     run: frontend
-  managedFields:
-  - apiVersion: v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          .: {}
-          f:run: {}
-      f:spec:
-        f:containers:
-          k:{"name":"frontend"}:
-            .: {}
-            f:args: {}
-            f:image: {}
-            f:imagePullPolicy: {}
-            f:name: {}
-            f:resources: {}
-            f:terminationMessagePath: {}
-            f:terminationMessagePolicy: {}
-        f:dnsPolicy: {}
-        f:enableServiceLinks: {}
-        f:restartPolicy: {}
-        f:schedulerName: {}
-        f:securityContext: {}
-        f:terminationGracePeriodSeconds: {}
     manager: kubectl
     operation: Update
-    time: "2020-08-10T21:01:00Z"
   name: frontend
   namespace: default
-  resourceVersion: "15280"
-  selfLink: /api/v1/namespaces/default/pods/frontend
-  uid: 063b1f98-1abf-4613-8361-1a3ff11ed453
 spec:
   containers:
   - args:

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -14,10 +14,6 @@ spec:
     resources: {}
     terminationMessagePath: /dev/termination-log
     terminationMessagePolicy: File
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-vftng
-      readOnly: true
     env:
       - name: PORT
         value: "8080"

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2020-08-10T21:01:00Z"
+  labels:
+    run: frontend
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:run: {}
+      f:spec:
+        f:containers:
+          k:{"name":"frontend"}:
+            .: {}
+            f:args: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl
+    operation: Update
+    time: "2020-08-10T21:01:00Z"
+  name: frontend
+  namespace: default
+  resourceVersion: "15280"
+  selfLink: /api/v1/namespaces/default/pods/frontend
+  uid: 063b1f98-1abf-4613-8361-1a3ff11ed453
+spec:
+  containers:
+  - args:
+    - —dry-run
+    image: sybertuk/hipster-demo:latest
+    imagePullPolicy: Always
+    name: frontend
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-vftng
+      readOnly: true
+    env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+      - name: ENV_PLATFORM
+        value: "gcp"
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-vftng
+    secret:
+      defaultMode: 420
+      secretName: default-token-vftng
+

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -3,10 +3,7 @@ kind: Pod
 metadata:
   labels:
     run: frontend
-    manager: kubectl
-    operation: Update
   name: frontend
-  namespace: default
 spec:
   containers:
   - args:

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,42 +1,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: "2020-08-10T21:20:34Z"
   labels:
     run: frontend
-  managedFields:
-  - apiVersion: v1
-    fieldsType: FieldsV1
-    fieldsV1:
-      f:metadata:
-        f:labels:
-          .: {}
-          f:run: {}
-      f:spec:
-        f:containers:
-          k:{"name":"frontend"}:
-            .: {}
-            f:args: {}
-            f:image: {}
-            f:imagePullPolicy: {}
-            f:name: {}
-            f:resources: {}
-            f:terminationMessagePath: {}
-            f:terminationMessagePolicy: {}
-        f:dnsPolicy: {}
-        f:enableServiceLinks: {}
-        f:restartPolicy: {}
-        f:schedulerName: {}
-        f:securityContext: {}
-        f:terminationGracePeriodSeconds: {}
     manager: kubectl
     operation: Update
-    time: "2020-08-10T21:20:34Z"
   name: frontend
   namespace: default
-  resourceVersion: "16157"
-  selfLink: /api/v1/namespaces/default/pods/frontend
-  uid: bda38d9e-2c00-462a-8c4f-f067e6aaac3e
 spec:
   containers:
   - args:

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -14,10 +14,6 @@ spec:
     resources: {}
     terminationMessagePath: /dev/termination-log
     terminationMessagePolicy: File
-    volumeMounts:
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-vftng
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2020-08-10T21:20:34Z"
+  labels:
+    run: frontend
+  managedFields:
+  - apiVersion: v1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:run: {}
+      f:spec:
+        f:containers:
+          k:{"name":"frontend"}:
+            .: {}
+            f:args: {}
+            f:image: {}
+            f:imagePullPolicy: {}
+            f:name: {}
+            f:resources: {}
+            f:terminationMessagePath: {}
+            f:terminationMessagePolicy: {}
+        f:dnsPolicy: {}
+        f:enableServiceLinks: {}
+        f:restartPolicy: {}
+        f:schedulerName: {}
+        f:securityContext: {}
+        f:terminationGracePeriodSeconds: {}
+    manager: kubectl
+    operation: Update
+    time: "2020-08-10T21:20:34Z"
+  name: frontend
+  namespace: default
+  resourceVersion: "16157"
+  selfLink: /api/v1/namespaces/default/pods/frontend
+  uid: bda38d9e-2c00-462a-8c4f-f067e6aaac3e
+spec:
+  containers:
+  - args:
+    - —dry-run
+    image: sybertuk/hipster-demo:latest
+    imagePullPolicy: Always
+    name: frontend
+    resources: {}
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    volumeMounts:
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      name: default-token-vftng
+      readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  priority: 0
+  restartPolicy: Never
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  volumes:
+  - name: default-token-vftng
+    secret:
+      defaultMode: 420
+      secretName: default-token-vftng
+status:
+  phase: Pending
+  qosClass: BestEffort

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1 # Версия API
+kind: Pod # Объект, который создаем
+metadata:
+  name: web # Название Pod
+  labels: # Метки в формате key: value
+    app: web
+spec: # Описание Pod
+  containers: # Описание контейнеров внутри Pod
+    - name: web # Название контейнера
+      image: sybertuk/hw1-web # Образ из которого создается контейнер
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  initContainers:
+    - name: init-web
+      image: busybox:latest
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}
+

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:latest
+EXPOSE 8000
+RUN apt update && apt install -y -q net-tools procps
+RUN userdel nginx && \
+    adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx --uid 1001 nginx
+RUN chmod 777 /var/cache/nginx && \
+    chmod 777 /var/run
+RUN mkdir /app && \
+    echo "test" > /app/test.html
+RUN sed -i -E 's/listen.+;/listen 8000;/g' /etc/nginx/conf.d/*.conf && \
+    sed -i -E 's/root.+;/root \/app;/g' /etc/nginx/conf.d/*.conf
+USER 1001


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [*] Основное ДЗ
 - [*] Задание со *

## В процессе сделано:
 - установлены kubectl, minikube, плагин dashboard, k9s
 - Выяснил почему системные поды core-dns, kubeapi-server и т.п. восстановились после удаления. core-dns запущен в виде deployment-а, контроль которого и приведение его (deployment-а) к задекларированному состоянию осуществляет kubernetes control plane. Остальные поды в namespace-e kube-system запущены как static pods, их запуск и перезапуск осуществляется kubelet демоном (в качествен параметра которому передает директория с манифестами в которых описаны статисные поды)
- Создал докер образ согласно заданию (запуск web сервиса на 8000 порту от UID 1001 в директории /app), а также опубликовал его в doker hub
- Создал манифест web-pod.yaml для запуска пода с созданным докер образом и с init контейнером
- Запустил pod web-pod.yaml и опубликовал на порту 0.0.0.0:8000
- Сделал dry-run hipster shop frontend получив yaml конфигурации а также пофиксил его для корректного запуска frontend-pod-healthy.yaml

## Как запустить проект:
 1. Запустить контейнер на базе созданного докер образа docker run --rm -d -p 8000:8000 sybertuk/hw1-web
 2. Запустить pod web-pod.yaml в кластере k8s kubectl apply -f web-pod.yaml
 3. Запустить pod hipster-shop frontend kubectl apply -f frontend-pod-healthy.yaml

## Как проверить работоспособность:
 1. После запуска Docker container-а перейти по ссылке http://localhost:8000
 2. После запуска pod-a  web-pod.yaml пробросить порт 8000 kubectl port-forward --address 0.0.0.0 pod/web 8000:8000 и перейти по ссылке http://localhost:8000
 3. Проверяем что  pod hipster-shop frontend запустился без ошибок kubectl get pod frontend


## PR checklist:
 - [*] Выставлен label с темой домашнего задания
